### PR TITLE
Add back ESL remote check and fix index errors

### DIFF
--- a/EUS.js
+++ b/EUS.js
@@ -78,6 +78,8 @@ module.exports = {
             res - Response from server
         */
         
+        if (req.query["stat"] == "get") return res.end('{ "status":1, "version":"'+global.internals.version+'" }');
+
         // Register the time at the start of the request
         d = new Date();
         startTime = d.getTime();
@@ -87,7 +89,8 @@ module.exports = {
         fs.access(__dirname + BASE_PATH + "/i/"+urs+image_json[urs], error => {
             if (error) {
                 // Doesn't exist, handle request normaly
-                fs.access(__dirname + BASE_PATH + "/files"+req.url, error => {
+                if (req.url === "/") { urs = "/index.html" } else { urs = req.url };
+                fs.access(__dirname + BASE_PATH + "/files"+urs, error => {
                     if (error) {
                         // Doesn't exist, send a 404 to the client.
                         res.status(404).end("404!");


### PR DESCRIPTION
ESL is a status logger for EUS and I didn't notice when we moved from the old PHP version to the new Revolution version that I neglected to include the check for it, so that was missing for months and months.

Also that index fix is that req.url returns a "/" when you go to index but has no file in the url. Express understands it but fs.access let it through so Express was printing an error to the console which looked a bit ugly and was a bug so I fixed it here too.