### PR TITLE
Add total disk space to space api

### DIFF
--- a/EUS.js
+++ b/EUS.js
@@ -281,8 +281,6 @@ function handleAPI(req, res) {
                     sizeOfFolder = (size / 1024 / 1024 / 1024);
                     jsonaa["space"]["usage"]["gb"] = sizeOfFolder;
                     jsonaa["space"]["usage"]["string"] = spaceToLowest(size, true);
-                    // Send the json to the requesting client
-                    d = new Date(); endTime = d.getTime();
                     diskUsage.check(__dirname, (err, data) => {
                         if (err) throw err;
                         jsonaa["space"]["total"] = {
@@ -293,6 +291,8 @@ function handleAPI(req, res) {
                             string: spaceToLowest(data["total"], true)
                         };
                     });
+                    // Send the json to the requesting client
+                    d = new Date(); endTime = d.getTime();
                     global.modules.consoleHelper.printInfo(emoji.heavy_check, `${req.method}: ${chalk.green("[200]")} ${req.url} ${endTime - startTime}ms`);
                     return res.end(JSON.stringify(jsonaa));
                 });

--- a/EUS.js
+++ b/EUS.js
@@ -280,7 +280,6 @@ function handleAPI(req, res) {
                     jsonaa["space"]["usage"]["mb"] = sizeOfFolder;
                     sizeOfFolder = (size / 1024 / 1024 / 1024);
                     jsonaa["space"]["usage"]["gb"] = sizeOfFolder;
-                    sizeOfFolder = (size / 1024 / 1024 / 1024).toFixed(2);
                     jsonaa["space"]["usage"]["string"] = spaceToLowest(size, true);
                     // Send the json to the requesting client
                     d = new Date(); endTime = d.getTime();

--- a/EUS.js
+++ b/EUS.js
@@ -281,6 +281,7 @@ function handleAPI(req, res) {
                     sizeOfFolder = (size / 1024 / 1024 / 1024);
                     jsonaa["space"]["usage"]["gb"] = sizeOfFolder;
                     jsonaa["space"]["usage"]["string"] = spaceToLowest(size, true);
+                    // Get total disk space
                     diskUsage.check(__dirname, (err, data) => {
                         if (err) throw err;
                         jsonaa["space"]["total"] = {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ EUS has extra dependencies other than those of [Revolution](https://github.com/t
  - [connect-busboy](https://www.npmjs.com/package/connect-busboy)
  - [randomstring](https://www.npmjs.com/package/randomstring)
  - [get-folder-size](https://www.npmjs.com/package/get-folder-size)
+ - [diskusage](https://www.npmjs.com/package/diskusage)
  
 Install the dependencies and then simply drop the EUS.js into a Revolution instance's modules folder **(If you still have [example_request_handler.js](https://github.com/tgpethan/Revolution/blob/master/modules/example_request_handler.js) be sure to delete it!)**
 

--- a/quick-setup.sh
+++ b/quick-setup.sh
@@ -5,4 +5,4 @@ npm i
 wget https://raw.githubusercontent.com/tgpethan/EUS/master/EUS.js -P modules/
 rm modules/example_request_handler.js
 cp config/config.example.json config/config.json
-npm i connect-busboy randomstring
+npm i connect-busboy randomstring diskusage get-folder-size


### PR DESCRIPTION
As mentioned currently by the readme of EUS-Web and [stated by the people who have used inspect element on the EUS frontend](https://ethanus.ml/l0aXu1HpCThlGn), the total disk space of EUS is currently hard-coded on the frontend which isn't great.

It was about time I got around to this since I've been putting it off for a long time, even going back the the PHP system.

This does mean EUS has a new dependency in the form of [diskusage](https://www.npmjs.com/package/diskusage)

This also means as a consequence the api endpoint for space has now grown in size in terms of it's output.

This **will** be a breaking change for everything using the space api